### PR TITLE
Unbreak comment links

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -114,7 +114,9 @@ class RedditBot:
             thumb = data.thumbnail if not data.is_self else self.config.sub_thumb
         elif isinstance(data, praw.models.Comment):
             p_type = 'Comment'
-            url = 'https://reddit.com' + data.permalink + '?context=1000'
+            # Current Reddit interface only supports up to 3 levels of context.
+            # More than 8 or so just doesn't load, 4-n will show context but not the actual linked comment.
+            url = 'https://reddit.com' + data.permalink + '?context=3'
             title = data.submission.title
             body = data.body
             thumb = self.config.comment_thumb


### PR DESCRIPTION
The current code links comments with `?context=1000` appended, in an attempt to show the full context tracing back to the original comment on the post. This doesn’t work, as the current interface (definitely on mobile, and I believe I tested on desktop as well) just never loads any comments.

Some testing has revealed 3 to be the largest context supported. More than 3 results in three levels of context being displayed, starting n levels above the linked-to comment, meaning that the comment itself is absent, and more than 8 or so (don’t remember the exact number) just breaks comment loading altogether.